### PR TITLE
Non-ASCII strings get corrupted on round-trip.

### DIFF
--- a/examples/client.js
+++ b/examples/client.js
@@ -7,7 +7,7 @@ var connection = thrift.createConnection('localhost', 9090),
     client = thrift.createClient(UserStorage, connection);
 
 var user = new ttypes.UserProfile({uid: 1,
-                                   name: "Mark Slee",
+                                   name: "Mark O\u2019Slee",
                                    blurb: "I'll find something to put here."});
 
 connection.on('error', function(err) {
@@ -18,12 +18,12 @@ client.store(user, function(err, response) {
   if (err) {
     console.error(err);
   } else {
-    console.log("stored:", user.uid);
+    console.log("stored:", user.uid, user.name);
     client.retrieve(user.uid, function(err, responseUser) {
       if (err) {
         console.error(err);
       } else {
-        console.log("retrieved:", responseUser.uid);
+        console.log("retrieved:", responseUser.uid, responseUser.name);
         connection.end();
       }
     });

--- a/lib/thrift/protocol.js
+++ b/lib/thrift/protocol.js
@@ -124,8 +124,10 @@ TBinaryProtocol.prototype.writeDouble = function(dub) {
 }
 
 TBinaryProtocol.prototype.writeString = function(str) {
-  this.writeI32(str.length);
-  this.trans.write(str);
+  // convert to utf8 here to get an accurate length
+  var buf = new Buffer(str, "utf8");
+  this.writeI32(buf.length);
+  this.trans.write(buf);
 }
 
 TBinaryProtocol.prototype.readMessageBegin = function() {
@@ -244,7 +246,7 @@ TBinaryProtocol.prototype.readBinary = function() {
 }
 
 TBinaryProtocol.prototype.readString = function() {
-  var r = this.readBinary().toString('binary');
+  var r = this.readBinary().toString('utf8');
   // console.log("readString: " + r);
   return r;
 }


### PR DESCRIPTION
Strings get coerced to ASCII by default, which there is no (good) coming back from.

The first push demonstrates the ASCII corruption problem.  The second push seeks to address the problem by explicitly transporting all strings in utf-8 form.

Please let me know if you would like a unit test and/or if I'm doing the pull request wrong.  This is my first pull request!
