### PR TITLE
Implemented StdIOClient and StdIOConnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,27 @@ Here is a Cassandra example:
       connection.end();
     });
 
+## Using Standard IO
+
+The StdIOClient and StdIOConnection was tested with: https://github.com/apache/thrift/blob/trunk/tutorial/php/PhpServer.php.
+However, the StdIOConnection should be able to interface with any process reading and writing to stdin and stdout using a thrift protocol.
+
+Here is a example:
+
+	var thrift = require('thrift'),
+			connection = thrift.createStdIOConnection('php PhpServer.php'),//the php server from above
+			client = thrift.createStdIOClient(someProcessor,connection);
+
+			client.someMethod(someParam,function(err,data){
+				if(!err){
+					console.log(data,"MADE IT HERE'S YOUR DATA");
+					return;
+				}
+
+				throw err;
+
+			});
+
 ## Libraries using node-thrift
 
 * [yukim/node_cassandra](https://github.com/yukim/node_cassandra)

--- a/lib/thrift/connection.js
+++ b/lib/thrift/connection.js
@@ -110,3 +110,115 @@ exports.createClient = function(cls, connection) {
 
   return client;
 }
+
+var child_process = require('child_process');
+var StdIOConnection = exports.StdIOConnection = function(command, options) {
+	var command_parts = command.split(' ');
+	command = command_parts[0];
+	var args = command_parts.splice(1,command_parts.length -1);
+	var child = this.child = child_process.spawn(command,args);
+
+  var self = this;
+  EventEmitter.call(this);
+
+	this._debug = options.debug || false;
+  this.connection = child.stdin;
+  this.options = options || {};
+  this.transport = this.options.transport || ttransport.TFramedTransport;
+  this.protocol = this.options.protocol || tprotocol.TBinaryProtocol;
+  this.offline_queue = [];
+
+	if(this._debug === true){
+
+  this.child.stderr.on('data',function(err){
+			console.log(err.toString(),'CHILD ERROR');
+
+		});
+
+	this.child.on('exit',function(code,signal){
+			console.log(code+':'+signal,'CHILD EXITED');
+
+		});
+
+	}
+
+	this.frameLeft = 0;
+	this.framePos = 0;
+	this.frame = null;
+	this.connected = true;
+
+	self.offline_queue.forEach(function(data) {
+			self.connection.write(data);
+	});
+
+
+  this.connection.addListener("error", function(err) {
+    self.emit("error", err);
+  });
+
+  // Add a close listener
+  this.connection.addListener("close", function() {
+    self.emit("close");
+  });
+
+  child.stdout.addListener("data", self.transport.receiver(function(transport_with_data) {
+    var message = new self.protocol(transport_with_data);
+    try {
+      var header = message.readMessageBegin();
+      var dummy_seqid = header.rseqid * -1;
+      var client = self.client;
+      client._reqs[dummy_seqid] = function(err, success){
+        transport_with_data.commitPosition();
+
+        var callback = client._reqs[header.rseqid];
+        delete client._reqs[header.rseqid];
+        if (callback) {
+          callback(err, success);
+        }
+      };
+      client['recv_' + header.fname](message, header.mtype, dummy_seqid);
+    }
+    catch (e) {
+      if (e instanceof ttransport.InputBufferUnderrunError) {
+        transport_with_data.rollbackPosition();
+      }
+      else {
+        throw e;
+      }
+    }
+  }));
+
+};
+
+sys.inherits(StdIOConnection, EventEmitter);     
+
+StdIOConnection.prototype.end = function() {
+  this.connection.end();
+}
+
+StdIOConnection.prototype.write = function(data) {
+  if (!this.connected) {
+    this.offline_queue.push(data);
+    return;
+  }
+  this.connection.write(data);
+}
+exports.createStdIOConnection = function(command,options){
+	return new StdIOConnection(command,options);
+
+};
+
+exports.createStdIOClient = function(cls,connection) {
+  if (cls.Client) {
+    cls = cls.Client;
+  }
+
+  var client = new cls(new connection.transport(undefined, function(buf) {
+		connection.write(buf);
+	}), connection.protocol);
+
+  // TODO clean this up
+  connection.client = client;
+
+  return client;
+}

--- a/lib/thrift/index.js
+++ b/lib/thrift/index.js
@@ -4,5 +4,7 @@ var connection = require('./connection');
 exports.Connection = connection.Connection;
 exports.createClient = connection.createClient;
 exports.createConnection = connection.createConnection;
+exports.createStdIOClient = connection.createStdIOClient;
+exports.createStdIOConnection = connection.createStdIOConnection;
 
 exports.createServer = require('./server').createServer;


### PR DESCRIPTION
Hey Wadey, I sent you a message last week about this, I finally got around to condensing my commits, and cleaning some stuff up. 

I added a readme entry, to explain what's going on, but just to review, essentially this commit allows you to pipe thrift encode stuff through Stdin and Stdout of a child process, instead of a network socket.

I took the existing connection object and modified it into another object called StdIOConnection. StdIOConnection takes a command(e.g. 'php server.php'), spawns it as a node child process, and links up the stdin and stdout buffers to transmit and receive thrift messages.

Let me know what you think.
