### PR TITLE
Fix two problems when using BufferedTransport

### DIFF
--- a/lib/thrift/server.js
+++ b/lib/thrift/server.js
@@ -38,16 +38,19 @@ exports.createServer = function(cls, handler, options) {
         stream.write(buf);
       }));
 
-      try {
-        processor.process(input, output);
-        transport_with_data.commitPosition();
-      }
-      catch (e) {
-        if (e instanceof ttransport.InputBufferUnderrunError) {
-          transport_with_data.rollbackPosition();
+      for (;;) {
+        try {
+          processor.process(input, output);
+          transport_with_data.commitPosition();
         }
-        else {
-          throw e;
+        catch (e) {
+          if (e instanceof ttransport.InputBufferUnderrunError) {
+            transport_with_data.rollbackPosition();
+              return;
+          }
+          else {
+            throw e;
+          }
         }
       }
     }));

--- a/lib/thrift/transport.js
+++ b/lib/thrift/transport.js
@@ -60,11 +60,11 @@ TFramedTransport.receiver = function(callback) {
         framePos = 0;
         data = data.slice(4, data.length);
       }
-      
+
       if (data.length >= frameLeft) {
         data.copy(frame, framePos, 0, frameLeft);
         data = data.slice(frameLeft, data.length);
-        
+
         frameLeft = 0;
         callback(new TFramedTransport(frame));
       } else if (data.length) {
@@ -119,7 +119,7 @@ TFramedTransport.prototype = {
       buf.copy(out, pos, 0);
       pos += buf.length;
     });
-    
+
     if (this.onFlush) {
       // TODO: optimize this better, allocate one buffer instead of both:
       var msg = new Buffer(out.length + 4);
@@ -161,14 +161,14 @@ TBufferedTransport.receiver = function(callback) {
 
 TBufferedTransport.prototype = {
   commitPosition: function(){
-    var unreadedSize = this.writeCursor - this.readCursor;
-    var bufSize = (unreadedSize * 2 > this.defaultReadBufferSize) ? unreadedSize * 2 : this.defaultReadBufferSize;
+    var unreadSize = this.writeCursor - this.readCursor;
+    var bufSize = (unreadSize * 2 > this.defaultReadBufferSize) ? unreadSize * 2 : this.defaultReadBufferSize;
     var buf = new Buffer(bufSize);
-    if (unreadedSize > 0) {
-      this.inBuf.copy(buf, 0, this.readCursor, unreadedSize);
+    if (unreadSize > 0) {
+      this.inBuf.copy(buf, 0, this.readCursor, this.writeCursor);
     }
     this.readCursor = 0;
-    this.writeCursor = unreadedSize;
+    this.writeCursor = unreadSize;
     this.inBuf = buf;
   },
   rollbackPosition: function(){
@@ -222,14 +222,14 @@ TBufferedTransport.prototype = {
     if (this.outCount < 1) {
       return;
     }
-    
+
     var msg = new Buffer(this.outCount),
         pos = 0;
     this.outBuffers.forEach(function(buf) {
       buf.copy(msg, pos, 0);
       pos += buf.length;
     });
-    
+
     if (this.onFlush) {
       this.onFlush(msg);
     }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     { "type" : "svn",
       "url" : "http://svn.apache.org/repos/asf/thrift/trunk/"
     },
-  "version": "0.7.0-dev",
+  "version": "0.7.0-recoset",
   "author":
     { "name": "Apache Thrift Developers",
       "email": "dev@thrift.apache.org",


### PR DESCRIPTION
There are two fixes here, both of which caused problems with node-flume-rpc (which only uses Buffered transport):
1.  The server only attempts to process a single message at a time when more than one message arrives at once in the buffer.  This means that messages get more and more delayed and the buffer bigger and bigger.  The fix is to continue to process messages until there's an underrun.
2.  Buffer.copy was called incorrectly (with the number of bytes to copy, not the end position as is required).  Makes no difference if one message arrives at a time, but when multiple messages arrive at once the commitPosition method truncates the data instead of merely shifting it.
