### PR TITLE
Server, catch exceptions caused by bad clients

### DIFF
--- a/lib/thrift/server.js
+++ b/lib/thrift/server.js
@@ -13,6 +13,7 @@ exports.createServer = function(cls, handler) {
   var processor = new cls(handler);
 
   return net.createServer(function(stream) {
+	var self=this;
     stream.on('data', int32FramedReceiver(function(data) {
       var input = new TBinaryProtocol(new TMemoryBuffer(data));
       var output = new TBinaryProtocol(new TMemoryBuffer(undefined, function(buf) {
@@ -20,10 +21,20 @@ exports.createServer = function(cls, handler) {
         var msg = new Buffer(buf.length + 4);
         binary.writeI32(msg, buf.length);
         buf.copy(msg, 4, 0, buf.length);
-        stream.write(msg);
+        try {
+            stream.write(msg);
+        } catch (exception) {
+            self.emit('error',exception);
+            stream.end();
+        }
       }));
 
-      processor.process(input, output);
+      try {
+        processor.process(input, output);
+      } catch (exception) {
+        self.emit('error',exception);
+        stream.end();
+      }
     }));
 
     stream.on('end', function() {


### PR DESCRIPTION
If a thrift level protocol error occurs. For instance one makes a few changes to the thrift IDL file and a client connects using the old API an unhandled exception can be thrown from the TBinaryProtocol class. By adding a try-catch to the process() call these errors can be caught, the connection closed, and an error event emitted.

This also occurs when the client closes the connection too early. The stream.write() will fail, causing the server to stop serving clients with an unhandled exception.
