### PR TITLE
bugs['web'] should be bugs['url'].

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     ],
   "bugs":
     { "mail": "dev@thrift.apache.org",
-      "web": "https://issues.apache.org/jira/browse/THRIFT"
+      "url": "https://issues.apache.org/jira/browse/THRIFT"
     },
   "directories" : { "lib" : "./lib/thrift" },
   "main": "./lib/thrift",


### PR DESCRIPTION
This prevents the npm warning:

`npm WARN thrift@0.7.0 package.json: bugs['web'] should probably be bugs['url']`
