### PR TITLE
fix #26: bug with doubles

### DIFF
--- a/lib/thrift/protocol.js
+++ b/lib/thrift/protocol.js
@@ -253,7 +253,7 @@ TBinaryProtocol.prototype.readI64 = function() {
 
 TBinaryProtocol.prototype.readDouble = function() {
   var buff = this.trans.read(8);
-  return BinaryParser.toFloat(buff);
+  return BinaryParser.toDouble(buff);
 }
 
 TBinaryProtocol.prototype.readBinary = function() {


### PR DESCRIPTION
The bug is about wrong reading double values. It seems
to be a mistype: it parses 8 bytes of buffer data
as a 4 bytes float instead of parsing it as a double.
The commit fixes it
