### PR TITLE
i64 overflow in javascript

### DIFF
--- a/lib/thrift/binary_parser.js
+++ b/lib/thrift/binary_parser.js
@@ -79,7 +79,10 @@ p.decodeFloat = function( data, precisionBits, exponentBits ){
 };
 p.decodeInt = function( data, bits, signed, forceBigEndian ){
   //console.log("decodeInt: ", data, bits, signed);
-  var b = new this.IBuffer( this.bigEndian||forceBigEndian, data ), x = b.readBits( 0, bits ), max = Math.pow( 2, bits );
+	if(bits > 53)
+		var b = new this.IBuffer( this.bigEndian||forceBigEndian, data ), x = b.readBits( bits-53, 53 )*(1 << (bits-53)), max = Math.pow( 2, bits );	
+	else
+  	var b = new this.IBuffer( this.bigEndian||forceBigEndian, data ), x = b.readBits( 0, bits ), max = Math.pow( 2, bits );
   return signed && x >= max / 2 ? x - max : x;
 };
 p.encodeFloat = function( data, precisionBits, exponentBits ){

--- a/lib/thrift/binary_parser.js
+++ b/lib/thrift/binary_parser.js
@@ -79,8 +79,12 @@ p.decodeFloat = function( data, precisionBits, exponentBits ){
 };
 p.decodeInt = function( data, bits, signed, forceBigEndian ){
   //console.log("decodeInt: ", data, bits, signed);
-	if(bits > 53)
+	if(bits > 53){
 		var b = new this.IBuffer( this.bigEndian||forceBigEndian, data ), x = b.readBits( bits-53, 53 )*(1 << (bits-53)), max = Math.pow( 2, bits );	
+		x += b.readBits( 0, bits-53 );
+		//console.log("decodeInt: ", data, bits, signed);
+		//console.log("result: ", x);
+	}
 	else
   	var b = new this.IBuffer( this.bigEndian||forceBigEndian, data ), x = b.readBits( 0, bits ), max = Math.pow( 2, bits );
   return signed && x >= max / 2 ? x - max : x;


### PR DESCRIPTION
If the parsing integer is longer than 53 bits (double's Significand),
1. The code will read the 53 most significant bits first
2. Then, add the less significant bits later

This way, we can read the most accurate value of long integer. 
(The most accurate value that can represent in javascript's number)
